### PR TITLE
Correct spelling of 'Lavender'

### DIFF
--- a/documentation.html
+++ b/documentation.html
@@ -165,7 +165,7 @@
                   <div class="pull-right dark" style="background-color:#967ADC"></div>
                 </div>
                 <div class="infos">
-                  <h4>LAVANDER</h4>
+                  <h4>LAVENDER</h4>
                   <p>#AC92EC, #967ADC</p>
                 </div>
               </div>


### PR DESCRIPTION
Corrected spelling of 'Lavender' from 'Lavander'
