### PR TITLE
Add IE11 as a supported browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ BOOTFLAT is an open source Flat UI KIT based on Bootstrap 3.1.0 CSS framework. I
 
 Bootflat is built on the foundations of Bootstrap, visioned in a stunning flat design. Bootstrap itself is a trusted, reliable and proven tool for developers. Built with `Sass 3.3.3`.
 
-Bootflat is compatible with the following browsers: `IE8, IE9, IE10, Firefox, Safari, Opera, Chrome`.
+Bootflat is compatible with the following browsers: `IE8, IE9, IE10, IE11, Firefox, Safari, Opera, Chrome`.
 
 Thanks for supporting our framework, and enjoy!
 
@@ -27,7 +27,7 @@ Bootflat's components are built with HTML5 and CSS3. The pages use `header`, `na
 Bootflat uses lightweight high-function plugins for maximum performance, keeping CSS and JS file sizes down.
 
 ### 4. Mobile first
-Bootflat is fully responsive, built for mobile-first in mind. It provides off screen navigation, and almost all the widgets are compatible with all screen sizes. 
+Bootflat is fully responsive, built for mobile-first in mind. It provides off screen navigation, and almost all the widgets are compatible with all screen sizes.
 
 ## Manual Start
 Install with [bower](http://bower.io/)?

--- a/getting-started.html
+++ b/getting-started.html
@@ -5,7 +5,7 @@
     <title>Getting Started - Bootflat</title>
     <!-- Sets initial viewport load and disables zooming  -->
     <meta name="viewport" content="initial-scale=1, maximum-scale=1, user-scalable=no">
-    <!-- SmartAddon.com Verification --> 
+    <!-- SmartAddon.com Verification -->
     <meta name="smartaddon-verification" content="936e8d43184bc47ef34e25e426c508fe" />
     <!-- site css -->
     <link rel="stylesheet" href="css/site.min.css">
@@ -72,7 +72,7 @@
               <dt>OOCSS Approach</dt>
               <dd>Object-based coding method encourages code reuse and creates faster and more efficient style sheets, which are easier to add to and maintain.</dd>
               <dt>Bootstrap 3.1.0 Support</dt>
-              <dd>Now Bootflat is supporting Bootstrap 3.1.0 as well.</dd> 
+              <dd>Now Bootflat is supporting Bootstrap 3.1.0 as well.</dd>
               <dt>Configurable Color Scheme</dt>
               <dd>You can change any or all of the colors if you wish. Bootflat is easy to configure and match to your brand's color scheme.</dd>
               <dt>Easy Installation</dt>
@@ -155,7 +155,7 @@
           ================================================== -->
           <div class="docs-article docs--start" id="browser-support">
             <h3>Browser Support</h3>
-            <p>As such, our browser support tends to be whatever Web View API is available to native on a given platform. For Bootflat v2.0.0, that means UIWebView for E8, IE9, IE10, Firefox, Safari, Opera, Chrome.</p>
+            <p>As such, our browser support tends to be whatever Web View API is available to native on a given platform. For Bootflat v2.0.0, that means UIWebView for E8, IE9, IE10, IE11, Firefox, Safari, Opera, Chrome.</p>
           </div>
           <!-- Free PSD
           ================================================== -->

--- a/index.html
+++ b/index.html
@@ -4,9 +4,9 @@
     <meta charset="utf-8">
     <title>Bootflat</title>
     <!-- Sets initial viewport load and disables zooming  -->
-    <meta name="viewport" content="initial-scale=1, maximum-scale=1, user-scalable=no"> 
-    <!-- SmartAddon.com Verification --> 
-    <meta name="smartaddon-verification" content="936e8d43184bc47ef34e25e426c508fe" />  
+    <meta name="viewport" content="initial-scale=1, maximum-scale=1, user-scalable=no">
+    <!-- SmartAddon.com Verification -->
+    <meta name="smartaddon-verification" content="936e8d43184bc47ef34e25e426c508fe" />
     <!-- site css -->
     <link rel="stylesheet" href="css/site.min.css">
     <link href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,800,700,400italic,600italic,700italic,800italic,300italic" rel="stylesheet" type="text/css">
@@ -46,7 +46,7 @@
           <img src="img/logo-index.png" alt="Bootflat: Advanced HTML5 Hybrid Mobile App Framework">
         </h1>
         <h2>BOOTFLAT is an open source Flat UI KIT based on Bootstrap 3.1.0 CSS framework. <br/>And, for the designers, we offer a <a href="free-psd.html">free PSD Download</a>. <br />It provides a faster, easier and less repetitive way for web developers or designers to create elegant web apps. </h2>
-        <h3>Compatible Browsers: IE8, IE9, IE10, Firefox, Safari, Opera, Chrome.</h3>
+        <h3>Compatible Browsers: IE8, IE9, IE10, IE11, Firefox, Safari, Opera, Chrome.</h3>
         <p class="download-link">
           <a class="btn btn-primary" href="https://github.com/Bootflat/Bootflat.github.io/archive/master.zip">Download (Version 2.0.0)</a>
         </p>
@@ -87,7 +87,7 @@
               <div class="features__photo"><img src="img/feature-css.png" /></div>
               <h4>HTML5 &amp; CSS3</h4>
               <p>Bootflat's components are built with HTML5 and CSS3. The pages use `header`, `nav` and `section` to build the layout. Bootflat also comes with several splendid color schemes built-in, and allows for easy customization.</p>
-            </div> 
+            </div>
           </div>
           <div class="row">
             <div class="col-md-6">
@@ -176,7 +176,7 @@
           </div>
         </div>
       </div>
-      
+
     </div>
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
I checked browser compatibility for Bootflat in Windows 8.1 and with IE 11 using BrowserStack and the site rendered fine. See here for screenshot: http://awesomescreenshot.com/0562j4ni1f

Afterwards, I edited the pages which referred to browser compatibility and added IE 11.

Cheers
![screen shot 2014-03-22 at 5 56 47 pm](https://f.cloud.github.com/assets/3394807/2490173/17d4d6a4-b198-11e3-9b35-6c47b0aec437.png)
