### PR TITLE
fix for sass 3.3.5

### DIFF
--- a/bootflat/scss/bootflat/_global.scss
+++ b/bootflat/scss/bootflat/_global.scss
@@ -56,7 +56,7 @@ $darkgray-light:              #656D78 !default;
 @mixin exports($name) {
   @if index($modules, $name) {
   } @else {
-    $modules: append($modules, $name);
+    $modules: append($modules, $name) !global;
     @content;
   }
 }


### PR DESCRIPTION
update syntax in _global.scss for sass 3.3.5 (last gem)
