### PR TITLE
Changed the button:active background color

### DIFF
--- a/bootflat/css/bootflat.css
+++ b/bootflat/css/bootflat.css
@@ -189,8 +189,8 @@ blockquote {
   border-color: #ccd1d9;
 }
 .btn-primary, .btn-primary:active, .btn-primary.active, .btn-primary.disabled, .btn-primary[disabled] {
-  background-color: #3bafda;
-  border-color: #3bafda;
+  background-color: #4fc1e9;
+  border-color: #4fc1e9;
 }
 .btn-primary:hover, .btn-primary:focus {
   background-color: #4fc1e9;


### PR DESCRIPTION
When an active button loses focus the Button didn’t look that it is
active. I changed that so that the button stays the same even when it
loses the focus (in some cases you want to see if the button was
pressed - for example when you use the button template on a radio
button)

http://getbootstrap.com/javascript/#buttons-checkbox-radio
