### PR TITLE
Fix One kin dye hex-number typo

### DIFF
--- a/color-picker-pink.html
+++ b/color-picker-pink.html
@@ -78,7 +78,7 @@
 		<div class="color-picker">
 			<div class="color-item" style="background-color:#F08F90;">
 				<span class="color-name">One kin dye</span><br>
-				<span class="hex-number">#F08F907</span><br>
+				<span class="hex-number">#F08F90</span><br>
 			</div>
 		</div>
 		<div class="color-picker">

--- a/color-picker.html
+++ b/color-picker.html
@@ -139,7 +139,7 @@
 		<div class="color-picker">
 			<div class="color-item" style="background-color:#F08F90;">
 				<span class="color-name">One kin dye</span><br>
-				<span class="hex-number">#F08F907</span><br>
+				<span class="hex-number">#F08F90</span><br>
 			</div>
 		</div>
 		<div class="color-picker">


### PR DESCRIPTION
Remove the 7 from the end of the hex-number for One kin dye in the UI on the color picker pink and color picker pages.